### PR TITLE
Impl dir comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ A library of functionality used to compare files written in Rust.
 
 ## Build from source
 ```sh
-git clone git@github.com:Num0Programmer/rapid-file-comparison-toolkit.git
-cd rapid-file-comparison-toolkit
+git clone git@github.com:Num0Programmer/rfctk.git
+cd rfctk
 rustc src/main.rs -o rfc
 ```
 

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -1,4 +1,4 @@
-use std::fs::File;
+use std::fs::{self, File, DirEntry};
 use std::io::BufReader;
 use std::io::prelude::*;
 
@@ -8,7 +8,26 @@ pub const FILE_ONE_SEL: usize = 1;
 pub const FILE_TWO_SEL: usize = 2;
 
 
-/// compares two files at given file paths - can be relative or absolute
+/// compares contents of a directory to a single file
+pub fn dir_file_cmp(dir: &String, file_str: &String) -> std::io::Result<()>
+{
+    // try to open directory
+    //let dir = fs::read_dir(&dir)?;
+
+    // try to open file
+    //let file = File::open(&file_str)?;
+
+    for entry in fs::read_dir(".")?
+    {
+        let dir = entry?;
+        println!("{:?}", dir.path());
+    }
+
+    Ok(())
+}
+
+
+/// compares two files at given file paths
 pub fn file_cmp(file_1_str: &String, file_2_str: &String) -> std::io::Result<()>
 {
     // try to open first file

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -4,23 +4,21 @@ use std::io::prelude::*;
 
 
 /// constants to increase readability when accessing command line input
-pub const FILE_ONE_SEL: usize = 1;
-pub const FILE_TWO_SEL: usize = 2;
+pub const ARG_ONE_SEL: usize = 1;
+pub const ARG_TWO_SEL: usize = 2;
 
 
 /// compares contents of a directory to a single file
-pub fn dir_file_cmp(dir: &String, file_str: &String) -> std::io::Result<()>
+pub fn dir_file_cmp(dir: &String, cmp_file_str: &String) -> std::io::Result<()>
 {
-    // try to open directory
-    //let dir = fs::read_dir(&dir)?;
-
-    // try to open file
-    //let file = File::open(&file_str)?;
-
     for entry in fs::read_dir(dir)?
     {
-        let dir = entry?;
-        println!("{:?}", dir.path());
+        let file_str = entry?.path()
+            .into_os_string()
+            .into_string()
+            .unwrap();
+
+        file_cmp(&file_str, cmp_file_str)?;
     }
 
     Ok(())
@@ -28,13 +26,13 @@ pub fn dir_file_cmp(dir: &String, file_str: &String) -> std::io::Result<()>
 
 
 /// compares two files at given file paths
-pub fn file_cmp(file_1_str: &String, file_2_str: &String) -> std::io::Result<()>
+pub fn file_cmp(file_str: &String, cmp_file_str: &String) -> std::io::Result<()>
 {
     // try to open first file
-    let file_1 = File::open(&file_1_str)?;
+    let file_1 = File::open(&file_str)?;
 
     // try to open second file
-    let file_2 = File::open(&file_2_str)?;
+    let file_2 = File::open(&cmp_file_str)?;
 
     // initialize comparison information
     let mut lines_equal = 0;
@@ -61,10 +59,10 @@ pub fn file_cmp(file_1_str: &String, file_2_str: &String) -> std::io::Result<()>
             // log line number and text from file(s)
             println!("Warning: The following lines do not match!");
             println!("{}: {}: {}",
-                file_1_str, processed_lines + 1, str_1_buf.trim()
+                file_str, processed_lines + 1, str_1_buf.trim()
             );
             println!("{}: {}: {}\n",
-                file_2_str, processed_lines + 1, str_2_buf.trim()
+                cmp_file_str, processed_lines + 1, str_2_buf.trim()
             );
         }
 

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -13,6 +13,7 @@ pub fn dir_file_cmp(dir: &String, cmp_file_str: &String) -> std::io::Result<()>
 {
     for entry in fs::read_dir(dir)?
     {
+        // convert path buffer into file path
         let file_str = entry?.path()
             .into_os_string()
             .into_string()

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -17,7 +17,7 @@ pub fn dir_file_cmp(dir: &String, file_str: &String) -> std::io::Result<()>
     // try to open file
     //let file = File::open(&file_str)?;
 
-    for entry in fs::read_dir(".")?
+    for entry in fs::read_dir(dir)?
     {
         let dir = entry?;
         println!("{:?}", dir.path());

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -1,4 +1,4 @@
-use std::fs::{self, File, DirEntry};
+use std::fs::{self, File};
 use std::io::BufReader;
 use std::io::prelude::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@ fn main() -> std::io::Result<()>
     let env_args: Vec<_> = env::args().collect();
 
     let key_tup = (
-        fs::metadata(&env_args[FILE_ONE_SEL])?.is_dir(),
-        fs::metadata(&env_args[FILE_TWO_SEL])?.is_dir()
+        fs::metadata(&env_args[ARG_ONE_SEL])?.is_dir(),
+        fs::metadata(&env_args[ARG_TWO_SEL])?.is_dir()
     );
     match key_tup
     {
@@ -20,13 +20,13 @@ fn main() -> std::io::Result<()>
         },
         // check for directory to file comparison
         (true, false) => {
-            dir_file_cmp(&env_args[FILE_ONE_SEL], &env_args[FILE_TWO_SEL])?;
+            dir_file_cmp(&env_args[ARG_ONE_SEL], &env_args[ARG_TWO_SEL])?;
         },
         (false, true) => {
-            dir_file_cmp(&env_args[FILE_TWO_SEL], &env_args[FILE_ONE_SEL])?;
+            dir_file_cmp(&env_args[ARG_TWO_SEL], &env_args[ARG_ONE_SEL])?;
         },
         // assume file to file comparison
-        _ => { file_cmp(&env_args[FILE_ONE_SEL], &env_args[FILE_TWO_SEL])?; }
+        _ => { file_cmp(&env_args[ARG_ONE_SEL], &env_args[ARG_TWO_SEL])?; }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::fs;
 
 use rapid_file_comparison_toolkit::comparison::*;
 
@@ -7,7 +8,17 @@ fn main() -> std::io::Result<()>
     // establish environment
     let env_args: Vec<_> = env::args().collect();
 
-    file_cmp(&env_args[FILE_ONE_SEL], &env_args[FILE_TWO_SEL])?;
+    // check for dir to file compare
+    if fs::metadata(&env_args[FILE_ONE_SEL])?.is_dir() ||
+        fs::metadata(&env_args[FILE_TWO_SEL])?.is_dir()
+    {
+        // compare directory/ies
+    }
+    // otherwise, assume comparing two files
+    else
+    {
+        file_cmp(&env_args[FILE_ONE_SEL], &env_args[FILE_TWO_SEL])?;
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,16 +8,25 @@ fn main() -> std::io::Result<()>
     // establish environment
     let env_args: Vec<_> = env::args().collect();
 
-    // check for dir to file compare
-    if fs::metadata(&env_args[FILE_ONE_SEL])?.is_dir() ||
+    let key_tup = (
+        fs::metadata(&env_args[FILE_ONE_SEL])?.is_dir(),
         fs::metadata(&env_args[FILE_TWO_SEL])?.is_dir()
+    );
+    match key_tup
     {
-        // compare directory/ies
-    }
-    // otherwise, assume comparing two files
-    else
-    {
-        file_cmp(&env_args[FILE_ONE_SEL], &env_args[FILE_TWO_SEL])?;
+        // check for directory to directory comparison
+        (true, true) => {
+            println!("Directory to directory comparison is not supported yet!");
+        },
+        // check for directory to file comparison
+        (true, false) => {
+            dir_file_cmp(&env_args[FILE_ONE_SEL], &env_args[FILE_TWO_SEL])?;
+        },
+        (false, true) => {
+            dir_file_cmp(&env_args[FILE_TWO_SEL], &env_args[FILE_ONE_SEL])?;
+        },
+        // assume file to file comparison
+        _ => { file_cmp(&env_args[FILE_ONE_SEL], &env_args[FILE_TWO_SEL])?; }
     }
 
     Ok(())


### PR DESCRIPTION
Added functionality to support directory to file comparison. The implementation is in such a way the user can pass the directory and file names in any order and the program will figure out which argument is the file and which is the directory.