### PR TITLE
Impl cmp stats struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rapid-file-comparison-toolkit"
+name = "rfctk"
 version = "0.1.0"
 edition = "2021"
 

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -8,6 +8,26 @@ pub const ARG_ONE_SEL: usize = 1;
 pub const ARG_TWO_SEL: usize = 2;
 
 
+/// structure to store statistics about the comparison
+pub struct ComparisonStats
+{
+    lines_equal: u32,
+    processed_lines: u32
+}
+
+impl ComparisonStats
+{
+    pub fn new() -> Self
+    {
+        Self
+        {
+            lines_equal: 0,
+            processed_lines: 0
+        }
+    }
+}
+
+
 /// compares contents of a directory to a single file
 pub fn dir_file_cmp(dir: &String, cmp_file_str: &String) -> std::io::Result<()>
 {
@@ -19,6 +39,7 @@ pub fn dir_file_cmp(dir: &String, cmp_file_str: &String) -> std::io::Result<()>
             .into_string()
             .unwrap();
 
+        println!("Comparing {} to {}...", file_str, cmp_file_str);
         file_cmp(&file_str, cmp_file_str)?;
     }
 
@@ -71,7 +92,7 @@ pub fn file_cmp(file_str: &String, cmp_file_str: &String) -> std::io::Result<()>
     }
 
     println!("{} lines processed", processed_lines);
-    println!("{} out of {} lines were equivalent.",
+    println!("{} out of {} lines were equivalent.\n",
         lines_equal, processed_lines
     );
 

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -11,8 +11,10 @@ pub const ARG_TWO_SEL: usize = 2;
 /// structure to store statistics about the comparison
 pub struct ComparisonStats
 {
-    pub lines_equal: u32,
-    pub processed_lines: u32
+    /// tracks number of lines which were equal between all files given
+    pub total_lines_equal: u32,
+    /// tracks number of lines which were processed between all files given
+    pub total_lines_processed: u32
 }
 
 impl ComparisonStats
@@ -21,8 +23,8 @@ impl ComparisonStats
     {
         Self
         {
-            lines_equal: 0,
-            processed_lines: 0
+            total_lines_equal: 0,
+            total_lines_processed: 0
         }
     }
 }
@@ -64,6 +66,11 @@ pub fn file_cmp(
     // try to open second file
     let file_2 = File::open(&cmp_file_str)?;
 
+    // tracks number of lines equal between these two files
+    let mut lines_equal = 0;
+    // tracks number of lines processed in these two files
+    let mut lines_processed = 0;
+
     // create BufReaders for files
     let mut file_1_buf = BufReader::new(file_1);
     let mut file_2_buf = BufReader::new(file_2);
@@ -77,7 +84,7 @@ pub fn file_cmp(
         // check line bufs eq
         if str_1_buf.eq(&str_2_buf)
         {
-            stats.lines_equal += 1;
+            lines_equal += 1;
         }
         // otherwise, assume lines are not equal
         else
@@ -85,15 +92,18 @@ pub fn file_cmp(
             // log line number and text from file(s)
             println!("Warning: The following lines do not match!");
             println!("{}: {}: {}",
-                file_str, stats.processed_lines + 1, str_1_buf.trim()
+                file_str, lines_processed + 1, str_1_buf.trim()
             );
             println!("{}: {}: {}\n",
-                cmp_file_str, stats.processed_lines + 1, str_2_buf.trim()
+                cmp_file_str, lines_processed + 1, str_2_buf.trim()
             );
         }
 
-        stats.processed_lines += 1;
+        lines_processed += 1;
     }
+
+    stats.total_lines_equal += lines_equal;
+    stats.total_lines_processed += lines_processed;
 
     Ok(())
 }

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -45,7 +45,7 @@ pub fn dir_file_cmp(
             .into_string()
             .unwrap();
 
-        println!("Comparing {} to {}...", file_str, cmp_file_str);
+        println!("Comparing {} to {}...\n", file_str, cmp_file_str);
         file_cmp(stats, &file_str, cmp_file_str)?;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,3 @@
 pub mod comparison;
+
+pub use comparison::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,9 @@ fn main() -> std::io::Result<()>
     // establish environment
     let env_args: Vec<_> = env::args().collect();
 
+    // initialize statistics structure
+    let mut stats = ComparisonStats::new();
+
     let key_tup = (
         fs::metadata(&env_args[ARG_ONE_SEL])?.is_dir(),
         fs::metadata(&env_args[ARG_TWO_SEL])?.is_dir()
@@ -20,14 +23,19 @@ fn main() -> std::io::Result<()>
         },
         // check for directory to file comparison
         (true, false) => {
-            dir_file_cmp(&env_args[ARG_ONE_SEL], &env_args[ARG_TWO_SEL])?;
+            dir_file_cmp(&mut stats, &env_args[ARG_ONE_SEL], &env_args[ARG_TWO_SEL])?;
         },
         (false, true) => {
-            dir_file_cmp(&env_args[ARG_TWO_SEL], &env_args[ARG_ONE_SEL])?;
+            dir_file_cmp(&mut stats, &env_args[ARG_TWO_SEL], &env_args[ARG_ONE_SEL])?;
         },
         // assume file to file comparison
-        _ => { file_cmp(&env_args[ARG_ONE_SEL], &env_args[ARG_TWO_SEL])?; }
+        _ => { file_cmp(&mut stats, &env_args[ARG_ONE_SEL], &env_args[ARG_TWO_SEL])?; }
     }
+
+    println!("{} lines processed", stats.processed_lines);
+    println!("{} out of {} lines were equivalent.",
+        stats.lines_equal, stats.processed_lines
+    );
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,9 +32,9 @@ fn main() -> std::io::Result<()>
         _ => { file_cmp(&mut stats, &env_args[ARG_ONE_SEL], &env_args[ARG_TWO_SEL])?; }
     }
 
-    println!("{} lines processed", stats.processed_lines);
+    println!("{} lines processed", stats.total_lines_processed);
     println!("{} out of {} lines were equivalent.",
-        stats.lines_equal, stats.processed_lines
+        stats.total_lines_equal, stats.total_lines_processed
     );
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fs;
 
-use rapid_file_comparison_toolkit::comparison::*;
+use rfctk::comparison::*;
 
 fn main() -> std::io::Result<()>
 {


### PR DESCRIPTION
Makes use of a structure to store statistics about comparison during runtime. This information is printed out to the user just before the program exits.