### PR TITLE
Impl file comparison

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bin]]
+name = "rfc"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = "1.0.75"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-all:
-	cargo build --release
-	cp target/release/rfctk /usr/local/bin
+test:
+	@echo "\n\033[1mRunning comparison between two duplicate files:\033[0m"
+	rfctk tests/data/test_file.txt tests/data/other_test_file.txt
+	@echo "\n\n\033[1mRunning comparison between a long and short file:\033[0m"
+	rfctk tests/data/test_file.txt tests/data/small_test_file.txt
 
 clean:
 	rm -rf target Cargo.lock

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+all:
+	cargo build --release
+	cp target/release/rfctk /usr/local/bin
+
+clean:
+	rm -rf target Cargo.lock

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 test:
 	@echo "\n\033[1mRunning comparison between two duplicate files:\033[0m"
-	rfctk tests/data/test_file.txt tests/data/other_test_file.txt
+	rfc tests/data/test_file.txt tests/data/other_test_file.txt
 	@echo "\n\n\033[1mRunning comparison between a long and short file:\033[0m"
-	rfctk tests/data/test_file.txt tests/data/small_test_file.txt
+	rfc tests/data/test_file.txt tests/data/small_test_file.txt
 
 clean:
 	rm -rf target Cargo.lock

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A library of functionality used to compare files written in Rust.
 ```sh
 git clone git@github.com:Num0Programmer/rfctk.git
 cd rfctk
-make
+cargo install --path .
 ```
 
 ## Use RFCTk

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ A library of functionality used to compare files written in Rust.
 ```sh
 git clone git@github.com:Num0Programmer/rfctk.git
 cd rfctk
-rustc src/main.rs -o rfc
+make
 ```
 
+## Use RFCTk
+
+### Compare two files
+
+### Compare a file to a directory

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -46,7 +46,6 @@ pub fn dir_file_cmp(
             .into_string()
             .unwrap();
 
-        println!("Comparing {} to {}...\n", file_str, cmp_file_str);
         file_cmp(stats, &file_str, cmp_file_str)?;
     }
 
@@ -78,6 +77,7 @@ pub fn file_cmp(
     let mut str_1_buf = String::new();
     let mut str_2_buf = String::new();
 
+    println!("Comparing {} to {}...\n", file_str, cmp_file_str);
     // read another line from both buffers until EOF for either file
     while file_1_buf.read_line(&mut str_1_buf)? > 0
         && file_2_buf.read_line(&mut str_2_buf)? > 0
@@ -100,6 +100,8 @@ pub fn file_cmp(
             );
         }
 
+        str_1_buf.clear();
+        str_2_buf.clear();
         lines_processed += 1;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,18 +18,24 @@ fn main() -> std::io::Result<()>
     match key_tup
     {
         // check for directory to directory comparison
-        (true, true) => {
+        (true, true) =>
+        {
             println!("Directory to directory comparison is not supported yet!");
         },
         // check for directory to file comparison
-        (true, false) => {
+        (true, false) =>
+        {
             dir_file_cmp(&mut stats, &env_args[ARG_ONE_SEL], &env_args[ARG_TWO_SEL])?;
         },
-        (false, true) => {
+        (false, true) =>
+        {
             dir_file_cmp(&mut stats, &env_args[ARG_TWO_SEL], &env_args[ARG_ONE_SEL])?;
         },
         // assume file to file comparison
-        _ => { file_cmp(&mut stats, &env_args[ARG_ONE_SEL], &env_args[ARG_TWO_SEL])?; }
+        _ =>
+        {
+            file_cmp(&mut stats, &env_args[ARG_ONE_SEL], &env_args[ARG_TWO_SEL])?;
+        }
     }
 
     println!("{} lines processed", stats.total_lines_processed);

--- a/tests/data/hello_world.c
+++ b/tests/data/hello_world.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int main()
+{
+    printf("Hello, World!\n");
+
+    return 0;
+}

--- a/tests/data/other_hello_world.c
+++ b/tests/data/other_hello_world.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+int main()
+{
+    printf("This is a longer hello...\n");
+    printf("Hello, World!\n");
+
+    return 0;
+}


### PR DESCRIPTION
Adds some changes to conform to how other Rust projects are installed (i.e. using `cargo install`). Changed name of binary. Adds two C files for comparison test.