### PR TITLE
Removed import of ansi_term::Style so there are no warnings of unused…

### DIFF
--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -1,4 +1,4 @@
-use ansi_term::{Colour::Yellow, Style};
+use ansi_term::Colour::Yellow;
 use std::fs::{self, File};
 use std::io::BufReader;
 use std::io::prelude::*;


### PR DESCRIPTION
… imports.